### PR TITLE
Add responsive portfolio-style homepage

### DIFF
--- a/src/static/activities.html
+++ b/src/static/activities.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mergington High School Activities</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="page-header activities-header">
+      <div class="header-inner">
+        <div>
+          <h1>Mergington High School</h1>
+          <p>Sign up for the activities that make your school year memorable.</p>
+        </div>
+        <a class="button button-secondary" href="index.html">← Home</a>
+      </div>
+    </header>
+
+    <main class="activities-main">
+      <section id="activities-container" class="section-panel">
+        <h3>Available Activities</h3>
+        <div id="activities-list">
+          <p>Loading activities...</p>
+        </div>
+      </section>
+
+      <section id="signup-container" class="section-panel">
+        <h3>Sign Up for an Activity</h3>
+        <form id="signup-form">
+          <div class="form-group">
+            <label for="email">Student Email:</label>
+            <input
+              type="email"
+              id="email"
+              required
+              placeholder="your-email@mergington.edu"
+            />
+          </div>
+          <div class="form-group">
+            <label for="activity">Select Activity:</label>
+            <select id="activity" required>
+              <option value="">-- Select an activity --</option>
+            </select>
+          </div>
+          <button type="submit">Sign Up</button>
+        </form>
+        <div id="message" class="hidden"></div>
+      </section>
+    </main>
+
+    <footer>
+      <p>&copy; 2026 Mergington High School</p>
+    </footer>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -3,48 +3,76 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Mergington High School Activities</title>
+    <title>Mergington High School Portfolio</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+    <header class="page-header homepage-header">
+      <div class="header-inner">
+        <div>
+          <h1>Mergington High School</h1>
+          <p>Connecting students with clubs, teams, and activities that spark curiosity and community.</p>
+        </div>
+        <a class="button button-primary" href="activities.html">View Activities</a>
+      </div>
     </header>
 
-    <main>
-      <section id="activities-container">
-        <h3>Available Activities</h3>
-        <div id="activities-list">
-          <!-- Activities will be loaded here -->
-          <p>Loading activities...</p>
+    <main class="homepage-main">
+      <section class="hero-panel">
+        <div class="hero-copy">
+          <p class="eyebrow">Student Life &amp; Activities</p>
+          <h2>Explore the activities that make school memorable.</h2>
+          <p class="hero-text">
+            From art and drama to math and sports, Mergington High School offers extracurricular experiences designed to build confidence, teamwork, and leadership.
+          </p>
+          <div class="cta-group">
+            <a class="button button-primary" href="activities.html">Browse Activities</a>
+            <a class="button button-secondary" href="#highlights">Why Join?</a>
+          </div>
+        </div>
+        <div class="hero-card">
+          <div>
+            <h3>Featured Opportunities</h3>
+            <ul>
+              <li>Chess Club - strategy, tournaments, and team play</li>
+              <li>Programming Class - build projects and learn coding fundamentals</li>
+              <li>Drama Club - perform, direct, and collaborate on school plays</li>
+            </ul>
+          </div>
         </div>
       </section>
 
-      <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
-        <form id="signup-form">
-          <div class="form-group">
-            <label for="email">Student Email:</label>
-            <input type="email" id="email" required placeholder="your-email@mergington.edu" />
-          </div>
-          <div class="form-group">
-            <label for="activity">Select Activity:</label>
-            <select id="activity" required>
-              <option value="">-- Select an activity --</option>
-              <!-- Activity options will be loaded here -->
-            </select>
-          </div>
-          <button type="submit">Sign Up</button>
-        </form>
-        <div id="message" class="hidden"></div>
+      <section id="highlights" class="section-panel homepage-panel">
+        <h3>What Makes Our Activities Special</h3>
+        <div class="highlight-grid">
+          <article class="feature-card">
+            <h4>Hands-on Learning</h4>
+            <p>Students gain practical experience through club projects, competitions, and performance opportunities.</p>
+          </article>
+          <article class="feature-card">
+            <h4>Community &amp; Leadership</h4>
+            <p>Every activity encourages students to collaborate, lead, and support each other.</p>
+          </article>
+          <article class="feature-card">
+            <h4>Flexible Participation</h4>
+            <p>Options span cultural, academic, and athletic interests so every student can find their fit.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section-panel homepage-panel">
+        <h3>Ready to get started?</h3>
+        <p>
+          Our extracurricular program is a great place to try something new, build skills, and connect with friends. Use the activities page to see available programs and sign up in seconds.
+        </p>
+        <div class="cta-group">
+          <a class="button button-primary" href="activities.html">Go to Activities</a>
+        </div>
       </section>
     </main>
 
     <footer>
       <p>&copy; 2026 Mergington High School</p>
     </footer>
-
-    <script src="app.js"></script>
   </body>
 </html>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -6,7 +6,6 @@
 }
 
 body {
-  font-family: Arial, sans-serif;
   line-height: 1.6;
   color: #333;
   max-width: 1200px;
@@ -15,13 +14,58 @@ body {
   background-color: #f5f5f5;
 }
 
+button,
+.button {
+  background-color: #1a237e;
+  color: white;
+  border: none;
+  padding: 12px 20px;
+  font-size: 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+button:hover,
+.button:hover {
+  background-color: #3949ab;
+}
+
+.button-secondary {
+  background-color: #ffffff;
+  color: #1a237e;
+  border: 2px solid #1a237e;
+}
+
+.button-secondary:hover {
+  background-color: #e8eaf6;
+}
+
+body,
+input,
+select,
+button {
+  font-family: Arial, sans-serif;
+}
+
+header,
+footer,
+.section-panel,
+.hero-panel,
+.hero-card {
+  border-radius: 12px;
+}
+
 header {
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
-  border-radius: 5px;
 }
 
 header h1 {
@@ -29,25 +73,15 @@ header h1 {
 }
 
 main {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 30px;
-  justify-content: center;
-}
-
-@media (min-width: 768px) {
-  main {
-    grid-template-columns: 2fr 1fr;
-  }
+  display: block;
 }
 
 section {
   background-color: white;
   padding: 20px;
-  border-radius: 5px;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
   width: 100%;
-  max-width: 500px;
 }
 
 section h3 {
@@ -61,8 +95,8 @@ section h3 {
   margin-bottom: 15px;
   padding: 15px;
   border: 1px solid #ddd;
-  border-radius: 5px;
-  background-color: #f9f9f9;
+  border-radius: 8px;
+  background-color: #fafafa;
 }
 
 .activity-card h4 {
@@ -89,25 +123,25 @@ section h3 {
 
 .participants-section ul {
   list-style-type: none;
-  padding-left: 5px;
+  padding-left: 0;
 }
 
 .participants-section ul li {
-  padding: 4px 0;
-  position: relative;
+  padding: 8px 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  border-bottom: 1px solid #eceff1;
 }
 
-/* Remove the bullet point pseudo-element */
-.participants-section ul li::before {
-  display: none;
+.participants-section ul li:last-child {
+  border-bottom: none;
 }
 
 .participant-email {
   flex-grow: 1;
-  margin-right: 8px;
+  margin-right: 10px;
+  color: #444;
 }
 
 .delete-btn {
@@ -115,10 +149,10 @@ section h3 {
   border: none;
   color: #c62828;
   cursor: pointer;
-  font-size: 14px;
-  padding: 2px 5px;
-  transition: all 0.2s;
-  border-radius: 3px;
+  font-size: 16px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
 }
 
 .delete-btn:hover {
@@ -136,38 +170,34 @@ section h3 {
 
 .form-group label {
   display: block;
-  margin-bottom: 5px;
+  margin-bottom: 8px;
   font-weight: bold;
 }
 
 .form-group input,
 .form-group select {
   width: 100%;
-  padding: 10px;
+  padding: 12px;
   border: 1px solid #ddd;
-  border-radius: 4px;
+  border-radius: 6px;
   font-size: 16px;
 }
 
-button {
-  background-color: #1a237e;
-  color: white;
-  border: none;
-  padding: 10px 15px;
-  font-size: 16px;
-  border-radius: 5px;
-  cursor: pointer;
-  transition: background-color 0.2s;
+.hidden {
+  display: none;
 }
 
-button:hover {
-  background-color: #3949ab;
+footer {
+  text-align: center;
+  margin-top: 30px;
+  padding: 20px;
+  color: #666;
 }
 
 .message {
   margin-top: 20px;
-  padding: 10px;
-  border-radius: 4px;
+  padding: 12px;
+  border-radius: 6px;
 }
 
 .success {
@@ -188,13 +218,155 @@ button:hover {
   border: 1px solid #bee5eb;
 }
 
-.hidden {
-  display: none;
+.page-header {
+  padding: 24px 30px;
+  margin-bottom: 30px;
 }
 
-footer {
-  text-align: center;
-  margin-top: 30px;
-  padding: 20px;
-  color: #666;
+.header-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.header-inner h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.header-inner p {
+  margin: 8px 0 0;
+  color: #f0f0ff;
+  max-width: 700px;
+}
+
+.page-header.homepage-header {
+  background: linear-gradient(135deg, #1a237e, #3949ab);
+}
+
+.page-header.activities-header {
+  background: #1a237e;
+}
+
+.homepage-main {
+  display: grid;
+  gap: 30px;
+}
+
+.hero-panel {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 30px;
+  padding: 40px;
+  background: white;
+}
+
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #1a237e;
+  font-weight: bold;
+  margin-bottom: 16px;
+}
+
+.hero-panel h2 {
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  margin-bottom: 20px;
+  line-height: 1.1;
+}
+
+.hero-text {
+  margin-bottom: 28px;
+  max-width: 620px;
+  color: #555;
+}
+
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.hero-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #e0e0e0;
+  background: #f7f8fc;
+  padding: 28px;
+}
+
+.hero-card h3 {
+  margin-bottom: 18px;
+  color: #1a237e;
+}
+
+.hero-card ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.hero-card li {
+  margin-bottom: 14px;
+  color: #444;
+  line-height: 1.6;
+}
+
+.homepage-panel {
+  padding: 32px;
+}
+
+.highlight-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(3, minmax(220px, 1fr));
+}
+
+.feature-card {
+  background: #f9fbff;
+  border: 1px solid #e3e9f7;
+  padding: 24px;
+}
+
+.feature-card h4 {
+  margin-bottom: 12px;
+  color: #1a237e;
+}
+
+@media (max-width: 900px) {
+  .hero-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .highlight-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 16px;
+  }
+
+  .header-inner,
+  .hero-panel {
+    padding: 0;
+  }
+
+  .hero-panel,
+  .section-panel,
+  .homepage-panel {
+    padding: 24px;
+  }
 }


### PR DESCRIPTION
This PR adds a responsive portfolio-style homepage to complement the existing activities UI.

## Changes
- Convert `index.html` to a portfolio homepage with hero section, featured opportunities, and highlights
- Move activity signup UI to new `activities.html` page
- Update `styles.css` with homepage layout, hero, cards, and button styles
- Preserve existing `app.js` functionality for activities page

## Testing
- Homepage loads at `/static/index.html`
- Activities page loads at `/static/activities.html`
- Navigation between pages works correctly
- Responsive design works on mobile and desktop

Closes #2